### PR TITLE
[queue] add redis-based queue for stats register

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/tnfy-link/client-go
 
 go 1.23.2
+
+require github.com/redis/go-redis/v9 v9.7.0
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
+github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=

--- a/queue/errors.go
+++ b/queue/errors.go
@@ -1,0 +1,7 @@
+package queue
+
+import "errors"
+
+var (
+	ErrEmptyQueue = errors.New("queue is empty")
+)

--- a/queue/stats.go
+++ b/queue/stats.go
@@ -1,0 +1,79 @@
+package queue
+
+import (
+	"context"
+	"encoding"
+	"encoding/json"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	keyStatsIncr = "queue:stats:incr"
+)
+
+type StatsIncrEvent struct {
+	LinkID string            `redis:"linkId"`
+	Labels map[string]string `redis:"labels"`
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *StatsIncrEvent) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, s)
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s *StatsIncrEvent) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(s)
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*StatsIncrEvent)(nil)
+	_ encoding.BinaryUnmarshaler = (*StatsIncrEvent)(nil)
+)
+
+type StatsQueue struct {
+	redis *redis.Client
+
+	key string
+}
+
+func (q *StatsQueue) Enqueue(ctx context.Context, event StatsIncrEvent) error {
+	return q.redis.RPush(ctx, q.key, &event).Err()
+}
+
+func (q *StatsQueue) Dequeue(ctx context.Context) (StatsIncrEvent, error) {
+	event := StatsIncrEvent{}
+
+	vals, err := q.redis.BLPop(ctx, time.Second, q.key).Result()
+	if err == redis.Nil {
+		return StatsIncrEvent{}, ErrEmptyQueue
+	}
+
+	if err != nil {
+		return StatsIncrEvent{}, err
+	}
+
+	if len(vals) != 2 {
+		return StatsIncrEvent{}, ErrEmptyQueue
+	}
+
+	if err := event.UnmarshalBinary([]byte(vals[1])); err != nil {
+		return StatsIncrEvent{}, err
+	}
+
+	return event, nil
+}
+
+func NewStatsQueue(redis *redis.Client) *StatsQueue {
+	if redis == nil {
+		panic("redis client is nil")
+	}
+
+	return &StatsQueue{
+		redis: redis,
+
+		key: keyStatsIncr,
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error type `ErrEmptyQueue` for handling empty queue scenarios.
	- Added functionality for managing a statistics queue using Redis, including methods to enqueue and dequeue events.
- **Dependencies**
	- Updated dependencies to include `github.com/redis/go-redis/v9`, `github.com/cespare/xxhash/v2`, and `github.com/dgryski/go-rendezvous`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->